### PR TITLE
Fix: Link C Math Library, Add Library Build Option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,7 @@
 project('lua', 'c', version : '5.3.0', license : 'mit')
 
+cc = meson.get_compiler('c')
+m_dep = cc.find_library('m', required : false)
+
 incdir = include_directories('src')
 subdir('src')

--- a/src/meson.build
+++ b/src/meson.build
@@ -34,9 +34,17 @@ src = [
   'linit.c',
 ]
 
+# LuaC requires a static library
+lualib_link = static_library('lua', src,
+  dependencies : m_dep)
+
 lualib = library('lua', src)
 
-executable('luai', 'lua.c',
-  link_with : lualib)
-executable('luac', 'luac.c',
-  link_with : lualib)
+luai = executable('luai', 'lua.c',
+  link_with : lualib_link,
+  dependencies : m_dep)
+luac = executable('luac', 'luac.c',
+  link_with : lualib_link,
+  dependencies : m_dep)
+
+test('luahello', luai, args : ['-e', 'print("hello")'])


### PR DESCRIPTION
**OVERVIEW**
This commit fixes an issue where the compiler flag `-lm` is required in
order for the build to work on Ubuntu Linux. In addition, it allows for
a boolean option `shared_lib` to be used to control whether or not a
shared library build is used.

**TEST PLAN**
This has been tested against a project using the meson build system.

This should close #3 
