### PR TITLE
Fixes LUA_USE_WINDOWS already declared warnings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,7 @@ elif host_machine.system() == 'darwin'
   add_project_arguments('-DLUA_USE_MACOSX', language : 'c')
   readline_dep = cc.find_library('readline')
 elif host_machine.system() == 'windows'
-  add_project_arguments('-DLUA_USE_WINDOWS', language : 'c')
+  # Lua will add LUA_USE_WINDOWS on its own
   readline_dep = []
 else
   readline_dep = []


### PR DESCRIPTION
Lua already declares its own version of LUA_USE_WINDOWs. Removing the compiler definition flag will fix the `warning C4005: 'LUA_USE_WINDOWS': macro redefinition` warnings on Windows.